### PR TITLE
fix: configure Vite to build to dist directory instead of public

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,6 @@ export default defineConfig({
     historyApiFallback: true, // ✅ Esta línea es la clave
   },
   build: {
-    outDir: "public",
+    outDir: "dist",
   },
 });


### PR DESCRIPTION
- Fixed incorrect outDir configuration that was causing build conflicts
- CSS variables now properly included in production build
- Resolves styling issues on Render deployment

🤖 Generated with [Claude Code](https://claude.ai/code)